### PR TITLE
SPM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
 bin
 build
+/.build
 *.log
-

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 5.5
+import PackageDescription
+
+let package = Package(
+    name: "TreeSitterClojure",
+    platforms: [.macOS(.v10_13), .iOS(.v11)],
+    products: [.library(name: "TreeSitterClojure", targets: ["TreeSitterClojure"])],
+    targets: [
+        .target(
+            name: "TreeSitterClojure",
+            path: ".",
+            exclude: [
+            ],
+            sources: [
+                "src/parser.c",
+            ],
+            resources: [
+                .copy("queries"),
+            ],
+            publicHeadersPath: "bindings/swift",
+            cSettings: [.headerSearchPath("src")]
+        ),
+    ]
+)

--- a/bindings/swift/TreeSitterClojure/clojure.h
+++ b/bindings/swift/TreeSitterClojure/clojure.h
@@ -1,0 +1,16 @@
+#ifndef TREE_SITTER_CLOJURE_H_
+#define TREE_SITTER_CLOJURE_H_
+
+typedef struct TSLanguage TSLanguage;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern TSLanguage *tree_sitter_clojure();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_CLOJURE_H_


### PR DESCRIPTION
This adds Swift bindings and Swift Package Manager (SPM) support. This should require no maintenance on your part, and should not impact the actual parsers in any way. Other similar changes were made here:

https://github.com/tree-sitter/tree-sitter-go
https://github.com/tree-sitter/tree-sitter-c
https://github.com/tree-sitter/tree-sitter-haskell

Happy to answer any questions!