### PR TITLE
Add explicitly defined dependency on nan v. 2.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "tree-sitter-clojure",
   "version": "0.0.12",
   "description": "Clojure grammar for tree-sitter",
+  "dependencies": {
+    "nan": "2.18.0"
+  },
   "tree-sitter": [
     {
       "scope": "source.clojure",


### PR DESCRIPTION
Closes #55. Could possibly use `2.16.0` instead, since that's apparently the first nan version to solve this issue on nan's end, but that's entirely untested right now. This shouldn't break anything as far as I'm aware, but I have no clue how to run the tests for this project; it does seem to work fine when building https://github.com/cursorless-dev/vscode-parse-tree, though. 